### PR TITLE
Added check for error/support for Blocks.Transactions mainnet and testnet

### DIFF
--- a/tests/mainnet/blocks.js
+++ b/tests/mainnet/blocks.js
@@ -43,14 +43,19 @@ module.exports.Transactions = function(test, common) {
   test('getting all transaction by blocks on mainnet', function(t) {
     common.setup(test, function(err, commonBlockchain) {
       commonBlockchain.Blocks.Transactions([blockId], function(err, blocks) {
-        t.equal(blocks.length, 1, "blocks.length should be 1")
-        var txs = blocks[0];
-        t.true(txs.length === 1 || txs.length === 70, "txs.length should be 1 or 70")
-        var tx = txs[0]
-        t.equal(tx.blockId, blockId, "tx.blockId should be blockId")
-        t.true(tx.txid === null || tx.txid === txid, "tx.txid should be null or txid")
-        t.true(tx.txId === null || tx.txId === txid, "tx.txId should be null or txid")
-        t.end()
+        if (err) {
+          console.log(err)
+          t.end()
+        } else {
+          t.equal(blocks.length, 1, "blocks.length should be 1")
+          var txs = blocks[0];
+          t.true(txs.length === 1 || txs.length === 70, "txs.length should be 1 or 70")
+          var tx = txs[0]
+          t.equal(tx.blockId, blockId, "tx.blockId should be blockId")
+          t.true(tx.txid === null || tx.txid === txid, "tx.txid should be null or txid")
+          t.true(tx.txId === null || tx.txId === txid, "tx.txId should be null or txid")
+          t.end()
+        }
       });
     })
   })

--- a/tests/mainnet/blocks.js
+++ b/tests/mainnet/blocks.js
@@ -49,7 +49,7 @@ module.exports.Transactions = function(test, common) {
         } else {
           t.equal(blocks.length, 1, "blocks.length should be 1")
           var txs = blocks[0];
-          t.true(txs.length === 1 || txs.length === 70, "txs.length should be 1 or 70")
+          t.equal(txs.length, 70, "txs.length should be 70")
           var tx = txs[0]
           t.equal(tx.blockId, blockId, "tx.blockId should be blockId")
           t.true(tx.txid === null || tx.txid === txid, "tx.txid should be null or txid")

--- a/tests/mainnet/transactions.js
+++ b/tests/mainnet/transactions.js
@@ -9,8 +9,8 @@ module.exports.Get = function(test, common) {
         t.equal(tx.txId, txid, "tx.txId should be txid")
         t.equal(tx.vin.length, 2, "tx.vin.length should be 2")
         var vin = tx.vin[0]
-        t.true(vin.txid === null || typeof(vin.txid) == "string", "tx.vin[0].txid should be txid")
-        t.true(vin.txId === null || typeof(vin.txId) == "string", "tx.vin[0].txId should be txid")
+        t.true(vin.txid === null || typeof(vin.txid) == "string", "tx.vin[0].txid should be of type string or null")
+        t.true(vin.txId === null || typeof(vin.txId) == "string", "tx.vin[0].txId should be of type string or null")
         t.true(vin.vout === null || typeof(vin.vout) == "number", "tx.vin[0].vout should be null or number")
         t.equal(tx.vout.length, 2, "tx.vout.length should be 2")
         var vout = tx.vout
@@ -18,8 +18,8 @@ module.exports.Get = function(test, common) {
         t.equal(output.value, 6980000, "output.value should be 6980000")
         t.true(output.index === null || output.index === 0, "output.index should be null or 0")
         t.true(output.n === null || output.n === 0, "output.n should be null or 0")
-        t.true(output.scriptPubKey.type === null || output.scriptPubKey.type === 'pubkeyhash', "output.scriptPubKey.type should be pubkeyhash")
-        t.true(output.scriptPubKey.hex === null || output.scriptPubKey.hex === "76a914b1f484a2202abcf00517f9c3f2fafe76b7b2cf0588ac", "output.scriptPubKey.hex should be 76a914b1f484a2202abcf00517f9c3f2fafe76b7b2cf0588ac")
+        t.true(output.scriptPubKey.type === null || output.scriptPubKey.type === 'pubkeyhash', "output.scriptPubKey.type should be pubkeyhash or null")
+        t.true(output.scriptPubKey.hex === null || output.scriptPubKey.hex === "76a914b1f484a2202abcf00517f9c3f2fafe76b7b2cf0588ac", "output.scriptPubKey.hex should be 76a914b1f484a2202abcf00517f9c3f2fafe76b7b2cf0588ac or null")
         t.end()
       });
     })
@@ -46,7 +46,7 @@ module.exports.Outputs = function(test, common) {
         t.equal(output.txId, txid, "output.txId should be txid")
         t.equal(output.value, 6980000, "output.value should be 6980000")
         t.equal(output.vout, 0, "output.vout should be 0")
-        t.true(output.scriptPubKey === null || output.scriptPubKey === '76a914b1f484a2202abcf00517f9c3f2fafe76b7b2cf0588ac', "output.scriptPubKey should be 76a914b1f484a2202abcf00517f9c3f2fafe76b7b2cf0588ac")
+        t.true(output.scriptPubKey === null || output.scriptPubKey === '76a914b1f484a2202abcf00517f9c3f2fafe76b7b2cf0588ac', "output.scriptPubKey should be 76a914b1f484a2202abcf00517f9c3f2fafe76b7b2cf0588ac or null")
         var change_output = txos[1]
         t.equal(change_output.txid, txid, "change_output.txid should be txid")
         t.equal(change_output.txId, txid, "change_output.txId should be txid")

--- a/tests/testnet/blocks.js
+++ b/tests/testnet/blocks.js
@@ -43,14 +43,19 @@ module.exports.Transactions = function(test, common) {
   test('getting all transaction by blocks on testnet', function(t) {
     common.setup(test, function(err, commonBlockchain) {
       commonBlockchain.Blocks.Transactions([blockId], function(err, blocks) {
-        t.equal(blocks.length, 1, "blocks.length should be 1")
-        var txs = blocks[0];
-        t.true(txs.length === 1 || txs.length === 6, "txs.length should be 1 or 6")
-        var tx = txs[0]
-        t.equal(tx.blockId, blockId, "tx.blockId should be blockId")
-        t.true(tx.txid === null || tx.txid === txid, "tx.txid should be null or txid")
-        t.true(tx.txId === null || tx.txId === txid, "tx.txId should be null or txid")
-        t.end()
+        if (err) {
+          console.log(err)
+          t.end()
+        } else {
+          t.equal(blocks.length, 1, "blocks.length should be 1")
+          var txs = blocks[0];
+          t.true(txs.length === 1 || txs.length === 6, "txs.length should be 1 or 6")
+          var tx = txs[0]
+          t.equal(tx.blockId, blockId, "tx.blockId should be blockId")
+          t.true(tx.txid === null || tx.txid === txid, "tx.txid should be null or txid")
+          t.true(tx.txId === null || tx.txId === txid, "tx.txId should be null or txid")
+          t.end()
+        }
       });
     })
   })

--- a/tests/testnet/blocks.js
+++ b/tests/testnet/blocks.js
@@ -49,7 +49,7 @@ module.exports.Transactions = function(test, common) {
         } else {
           t.equal(blocks.length, 1, "blocks.length should be 1")
           var txs = blocks[0];
-          t.true(txs.length === 1 || txs.length === 6, "txs.length should be 1 or 6")
+          t.equal(txs.length, 6, "txs.length should be 6")
           var tx = txs[0]
           t.equal(tx.blockId, blockId, "tx.blockId should be blockId")
           t.true(tx.txid === null || tx.txid === txid, "tx.txid should be null or txid")

--- a/tests/testnet/transactions.js
+++ b/tests/testnet/transactions.js
@@ -12,7 +12,7 @@ module.exports.Get = function(test, common) {
         var vin = tx.vin[0];
         t.equal(vin.txid, output_txid, "tx.vin[0].txid should be txid")
         t.equal(vin.txId, output_txid, "tx.vin[0].txId should be txid")
-        t.true(vin.vout === null || vin.vout === 1, "tx.vin[0].vout should be 1")
+        t.true(vin.vout === null || vin.vout === 1, "tx.vin[0].vout should be 1 or null")
         t.equal(tx.vout.length, 2, "tx.vin.length should be 2")
         var vout = tx.vout
         var op_return_output = vout[0]
@@ -55,7 +55,7 @@ module.exports.Outputs = function(test, common) {
         t.equal(op_return_output.txId, txid, "op_return_output.txId should be txid")
         t.equal(op_return_output.value, 0, "op_return_output.value should be 0")
         t.equal(op_return_output.vout, 0, "op_return_output.vout should be 0")
-        t.true(op_return_output.scriptPubKey === null || op_return_output.scriptPubKey === '6a281f00042d8ccd0e823010845fa5e99968ff96166f3e4aa15b6d4420b089a0f1dd5dd4cbce6666be79', "op_return_output.scriptPubKey should be 6a281f00042d8ccd0e823010845fa5e99968ff96166f3e4aa15b6d4420b089a0f1dd5dd4cbce6666be79")
+        t.true(op_return_output.scriptPubKey === null || op_return_output.scriptPubKey === '6a281f00042d8ccd0e823010845fa5e99968ff96166f3e4aa15b6d4420b089a0f1dd5dd4cbce6666be79', "op_return_output.scriptPubKey should be 6a281f00042d8ccd0e823010845fa5e99968ff96166f3e4aa15b6d4420b089a0f1dd5dd4cbce6666be79 or null")
         var change_output = txos[1]
         t.equal(change_output.txid, txid, "change_output.txid should be txid")
         t.equal(change_output.txId, txid, "change_output.txId should be txid")


### PR DESCRIPTION
Biteasy does not support Blocks.Transactions - no txid/txId is returned from input of block id.
